### PR TITLE
🛠🐛💣 [Bug Fix] Fix broken CI testing about incorrect command line which has been changing to ``mock`` from ``mock-server``.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -147,4 +147,4 @@ jobs:
       build-type: poetry
       python_package_name: pymock-server
       test_shell_in_python: from pymock_server.model import APIConfig
-      test_shell: mock-server --help
+      test_shell: mock --help


### PR DESCRIPTION
### _Target_

*  Fix broken CI testing about incorrect command line which has been changing to ``mock`` from ``mock-server``.


### _Effecting Scope_

* Fix broken CI.


### _Description_

* Fix using incorrect command line to run pre-release testing.
