### PR TITLE
🤖⚙️🔧 [Improvement] Improve about it should print help information if user runs command line directly without any options or subcommand lines.

### DIFF
--- a/pymock_server/command/component.py
+++ b/pymock_server/command/component.py
@@ -5,5 +5,5 @@ from ._base.component import BaseSubCmdComponent, ParserArgumentsType
 
 class NoSubCmdComponent(BaseSubCmdComponent):
     def process(self, parser: ArgumentParser, args: ParserArgumentsType) -> None:
-        # FIXME: Should be fix this issue as rest-server
-        pass
+        print("⚠️ warn: please operate on this command with one more options or subcommand line you need.")
+        parser.parse_args(args=["--help"])

--- a/test/integration_test/runner.py
+++ b/test/integration_test/runner.py
@@ -43,6 +43,27 @@ class CommandFunctionTestSpec(metaclass=ABCMeta):
             assert re.search(expected_char, target, re.IGNORECASE)
 
 
+class TestCmdMock(CommandFunctionTestSpec):
+    @property
+    def options(self) -> str:
+        return ""
+
+    def test_command(self, runner: CommandRunner):
+        with Capturing() as output:
+            with pytest.raises(SystemExit):
+                with patch.object(sys, "argv", [""]):
+                    args = runner.parse(cmd_args=self.options.split())
+                    runner.run(cmd_args=args)
+        self.verify_running_output(" ".join(output))
+
+    def verify_running_output(self, cmd_running_result: str) -> None:
+        self._should_contains_chars_in_result(cmd_running_result, "mock [SUBCOMMAND] [OPTIONS]")
+        self._should_contains_chars_in_result(cmd_running_result, "-h, --help")
+        self._should_contains_chars_in_result(cmd_running_result, "-v, --version")
+        self._should_contains_chars_in_result(cmd_running_result, "subcommands:")
+        self._should_contains_chars_in_result(cmd_running_result, SubCommandLine.RestServer.value)
+
+
 class TestHelp(CommandFunctionTestSpec):
     @property
     def options(self) -> str:


### PR DESCRIPTION
### _Target_

* Improve about it should print help information if user runs command line directly without any options or subcommand lines.
* Key point example:
    * as is
    ```shell
    >>> mock
    >>> 
    ```
    * to be
    ```shell
    >>> mock
    ⚠️ warn: please operate on this command with one more options or subcommand line you need.
    usage: mock [SUBCOMMAND] [OPTIONS]
    
    A Python tool for mocking APIs by set up an application easily. PyMock-API bases on Python framework to set up application, i.e., for REST API, you could select using *flask* to set up application to mock APIs.
    
    options:
      -h, --help     show this help message and exit
      -v, --version  The version info of PyMock-Server.
    
    subcommands:
    
      {rest-server}
        rest-server  Set up an application to mock HTTP server which adopts REST API to communicate between client and server.
    >>> 
    ```


### _Effecting Scope_

* No any breaking changes.


### _Description_

* Let program show the help details info if user users unexpected way to run command line.
