### PR TITLE
🤖⚙️🔧 [Improvement] Improve the dependency setting of Python package **PyMock-Server**.

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -21,11 +21,20 @@ The dependencies which are necessary to install decreases greatly.
 
 !!! note "What the option _web framework_ we could use?"
 
-    **_PyMock-Server_** uses the Python web framework to implement the API feature. It means that it would also depend on other
-    Python package which for web development. Currrently, it supports 2 frameworks of all popular Python web framerworks
-    --- [**_Flask_**] and [**_FastAPI_**]. So the options value we could use are: ``auto``, ``flask`` or ``fastapi``. The 
-    option ``auto`` means that it would automatically scan which Python web framework it would use in the current Python 
-    runtime environment where the command line tool runs in.
+    **_PyMock-Server_** uses the Python web framework to implement the API feature. It means that it would also depend 
+    on other Python package which for web development. Currrently, it supports 2 frameworks of all popular Python web 
+    framerworks --- [**_Flask_**] and [**_FastAPI_**]. So the options value we could use are: ``mini``, ``auto``, 
+    ``flask`` or ``fastapi``.
+    
+    * ``mini``
+
+        It would install the minimum level depdendency of Python package. It also means it won't install both of web 
+        frameworks **_Flask_** or **_FastAPI_**.
+
+    * ``auto``
+
+        The option ``auto`` means that it would automatically scan which Python web framework it would use in the current 
+        Python runtime environment where the command line tool runs in.
 
   [**_Flask_**]: https://flask.palletsprojects.com/en/2.3.x/
   [**_FastAPI_**]: https://fastapi.tiangolo.com

--- a/poetry.lock
+++ b/poetry.lock
@@ -1388,13 +1388,13 @@ typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
 name = "pydantic-extra-types"
-version = "2.10.0"
+version = "2.10.1"
 description = "Extra Pydantic types."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pydantic_extra_types-2.10.0-py3-none-any.whl", hash = "sha256:b19943914e6286548254f5079d1da094e9c0583ee91a8e611e9df24bfd07dbcd"},
-    {file = "pydantic_extra_types-2.10.0.tar.gz", hash = "sha256:552c47dd18fe1d00cfed75d9981162a2f3203cf7e77e55a3d3e70936f59587b9"},
+    {file = "pydantic_extra_types-2.10.1-py3-none-any.whl", hash = "sha256:db2c86c04a837bbac0d2d79bbd6f5d46c4c9253db11ca3fdd36a2b282575f1e2"},
+    {file = "pydantic_extra_types-2.10.1.tar.gz", hash = "sha256:e4f937af34a754b8f1fa228a2fac867091a51f56ed0e8a61d5b3a6719b13c923"},
 ]
 
 [package.dependencies]
@@ -1406,7 +1406,7 @@ all = ["pendulum (>=3.0.0,<4.0.0)", "phonenumbers (>=8,<9)", "pycountry (>=23)",
 pendulum = ["pendulum (>=3.0.0,<4.0.0)"]
 phonenumbers = ["phonenumbers (>=8,<9)"]
 pycountry = ["pycountry (>=23)"]
-python-ulid = ["python-ulid (>=1,<2)", "python-ulid (>=1,<3)"]
+python-ulid = ["python-ulid (>=1,<2)", "python-ulid (>=1,<4)"]
 semver = ["semver (>=3.0.2)"]
 
 [[package]]
@@ -2501,4 +2501,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "8c593ee1b58252d7d7f32a26a51eb3ab3c85caad568f8c5499a6e300f2b210cb"
+content-hash = "5e799593bde72dde51acb452613cf3ed13bb40c9d93ab1d52038aa4b6c4cb9db"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ documentation = "https://chisanan232.github.io/PyMock-Server/"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-PyYAML = "^6.0"
+PyYAML = {version = "^6.0", extras = ["mini", "all"]}
 # Extra dependency of web framework *Flask* with WSGI server *Gunicorn*
 Flask = {version = "^3.0.2", extras = ["flask", "all"]}
 gunicorn = {version = ">=21.2,<24.0", extras = ["flask", "all"]}


### PR DESCRIPTION
### _Target_

* Improve the dependency setting of Python package **PyMock-Server**.
* Key point:
    * as is: must to install one of web framework when install ``pymock-server``
    ```shell
    >>> pip3 install "pymock-server[<web framework>]"
    ```
    * to be: has one more option could let developers install ``pymock-server`` with minimum level dependency without all web framework.
    ```shell
    >>> pip3 install "pymock-server[mini]"
    ```


### _Effecting Scope_

* No any breaking changes.


### _Description_

* Modify the dependency setting in Python project management tool Poetry.
* Update the relative content in documentation.
