### PR TITLE
🤖⚙️🔧 [Improvement] Add more checking condition to let configuration validation be more reasonable between property ``value_type`` and ``format``.

### DIFF
--- a/pymock_server/model/api_config/_base.py
+++ b/pymock_server/model/api_config/_base.py
@@ -134,6 +134,22 @@ class _Checkable(metaclass=ABCMeta):
                 return valid_callback(config_key, config_value)
             return True
 
+    def should_be_none(
+        self,
+        config_key: str,
+        config_value: Any,
+        accept_empty: bool = True,
+        err_msg: Optional[str] = None,
+    ) -> bool:
+        if (config_value is not None) or (accept_empty and config_value):
+            logger.error(err_msg if err_msg else f"Configuration *{config_key}* content should be None or empty.")
+            self._config_is_wrong = True
+            if self._stop_if_fail:
+                self._exit_program(1)
+            return False
+        else:
+            return True
+
     def props_should_not_be_none(
         self,
         under_check: dict,
@@ -147,6 +163,22 @@ class _Checkable(metaclass=ABCMeta):
                 config_value=v,
                 accept_empty=accept_empty,
                 valid_callback=valid_callback,
+                err_msg=err_msg,
+            ):
+                return False
+        return True
+
+    def props_should_be_none(
+        self,
+        under_check: dict,
+        accept_empty: bool = True,
+        err_msg: Optional[str] = None,
+    ) -> bool:
+        for k, v in under_check.items():
+            if not self.should_be_none(
+                config_key=k,
+                config_value=v,
+                accept_empty=accept_empty,
                 err_msg=err_msg,
             ):
                 return False

--- a/pymock_server/model/api_config/apis/_property.py
+++ b/pymock_server/model/api_config/apis/_property.py
@@ -1,5 +1,6 @@
 from abc import ABC
 from dataclasses import dataclass, field
+from pydoc import locate
 from typing import Any, Dict, List, Optional, Type
 
 from pymock_server.model.api_config._base import _Config, _HasItemsPropConfig
@@ -95,6 +96,13 @@ class BaseProperty(_HasItemsPropConfig, _HasFormatPropConfig, _BaseTemplateAcces
         if not self._prop_items_is_work():
             return False
 
+        assert self.value_type
+        if locate(self.value_type) in [list, dict] and not self.props_should_be_none(
+            under_check={
+                f"{self.absolute_model_key}.format": self.value_format,
+            },
+        ):
+            return False
         # check 'format' and 'items'
         format_and_items_chk = super().is_work()
         if format_and_items_chk is False:

--- a/pymock_server/model/api_config/item.py
+++ b/pymock_server/model/api_config/item.py
@@ -91,13 +91,14 @@ class IteratorItem(_HasFormatPropConfig, _HasItemsPropConfig):
         ):
             return False
         assert self.value_type
-        if locate(self.value_type) in [list, dict] and not self.props_should_not_be_none(
-            under_check={
-                f"{self.absolute_model_key}.items": self.items,
-            },
-            accept_empty=False,
-        ):
-            return False
+        if locate(self.value_type) in [list, dict]:
+            if not self.props_should_not_be_none(
+                under_check={
+                    f"{self.absolute_model_key}.items": self.items,
+                },
+                accept_empty=False,
+            ):
+                return False
 
         # check 'items'
         items_chk = super().is_work()

--- a/pymock_server/model/api_config/item.py
+++ b/pymock_server/model/api_config/item.py
@@ -100,6 +100,13 @@ class IteratorItem(_HasFormatPropConfig, _HasItemsPropConfig):
             ):
                 return False
 
+            if not self.props_should_be_none(
+                under_check={
+                    f"{self.absolute_model_key}.format": self.value_format,
+                },
+            ):
+                return False
+
         # check 'items'
         items_chk = super().is_work()
         if items_chk is False:

--- a/test/data/check_test/config/invalid/mockapis_api_name_http_response_object-with_iterable_type_miss_items.yaml
+++ b/test/data/check_test/config/invalid/mockapis_api_name_http_response_object-with_iterable_type_miss_items.yaml
@@ -1,0 +1,13 @@
+mocked_apis:
+  apis:
+    google_home:
+      url: '/google'
+      http:
+        request:
+          method: 'GET'
+        response:
+          strategy: object
+          properties:
+            - name: data
+              required: True
+              type: list

--- a/test/data/check_test/config/invalid/mockapis_api_name_http_response_object-with_iterable_type_with_format.yaml
+++ b/test/data/check_test/config/invalid/mockapis_api_name_http_response_object-with_iterable_type_with_format.yaml
@@ -1,0 +1,19 @@
+mocked_apis:
+  apis:
+    google_home:
+      url: '/google'
+      http:
+        request:
+          method: 'GET'
+        response:
+          strategy: object
+          properties:
+            - name: data
+              required: True
+              type: list
+              format:
+                strategy: 'by_data_type'
+              items:
+                - name: column1
+                  required: True
+                  type: int

--- a/test/data/check_test/data_model/item/invalid/list_type_with_redundant_format_in_items.yaml
+++ b/test/data/check_test/data_model/item/invalid/list_type_with_redundant_format_in_items.yaml
@@ -1,0 +1,9 @@
+name: "value"
+required: true
+type: list
+format:
+  strategy: 'by_data_type'
+items:
+  - name: "column"
+    required: true
+    type: str

--- a/test/data/check_test/data_model/request/invalid/param_iterable_arg_with_format.yaml
+++ b/test/data/check_test/data_model/request/invalid/param_iterable_arg_with_format.yaml
@@ -1,0 +1,12 @@
+method: 'PUT'
+parameters:
+  - name: 'arg1'
+    required: false
+    default: []
+    type: list
+    format:
+      strategy: 'by_data_type'
+    items:
+      - name: "column"
+        required: true
+        type: str

--- a/test/data/check_test/data_model/response/invalid/object_response_with_invalid_properties_with_iterable_type_with_format.yaml
+++ b/test/data/check_test/data_model/response/invalid/object_response_with_invalid_properties_with_iterable_type_with_format.yaml
@@ -1,0 +1,11 @@
+strategy: object
+properties:
+  - name: description
+    required: True
+    type: list
+    format:
+      strategy: 'by_data_type'
+    items:
+      - name: "column"
+        required: true
+        type: str


### PR DESCRIPTION
### _Target_

* Add more checking condition to let configuration validation be more reasonable between property ``value_type`` and ``format``.
* Key point change example:
    * as is: below configuration is valid
    ```yaml
    name: data_list
    type: list
    format:
        strategy: 'some format strategy'
    items:
        - name: col1
           type: str
           required: true
    ```
    * to be: below configuration is invalid because the property ``format`` should not be here if ``value_type`` is iterable.
    ```yaml
    name: data_list
    type: list
    format:
        strategy: 'some format strategy'
    items:
        - name: col1
           type: str
           required: true
    ```


### _Effecting Scope_

* No any breaking changes.


### _Description_

* Add more checking condition between properties ``value_type`` and ``format`` to be reasonable. When the value type is iterable, it should not have any format setting at all.
