### PR TITLE
[CU-86er1mm6d] Rename the data model about URI scheme to be correct (refer RFC)

### DIFF
--- a/pymock_server/_utils/random.py
+++ b/pymock_server/_utils/random.py
@@ -7,7 +7,7 @@ from collections import namedtuple
 from decimal import Decimal
 from typing import Any, List, Optional, Sequence
 
-from pymock_server._utils.uri_protocol import IPVersion, URISchema
+from pymock_server._utils.uri_protocol import IPVersion, URIScheme
 
 ValueSize = namedtuple("ValueSize", ("min", "max"), defaults=(-127, 128))
 DigitRange = namedtuple("DigitRange", ("integer", "decimal"))
@@ -126,52 +126,52 @@ class RandomIP(BaseRandomGenerator):
 
 class RandomURI(BaseRandomGenerator):
     @classmethod
-    def generate(cls, schema: URISchema = URISchema.HTTPS) -> str:
+    def generate(cls, schema: URIScheme = URIScheme.HTTPS) -> str:
         return cls._generate_uri_by_schema(schema)
 
     @classmethod
-    def _generate_uri_by_schema(cls, schema: URISchema) -> str:
-        if schema in (URISchema.HTTP, URISchema.HTTPS):
+    def _generate_uri_by_schema(cls, schema: URIScheme) -> str:
+        if schema in (URIScheme.HTTP, URIScheme.HTTPS):
             # ex: http://www.ietf.org/rfc/rfc2396.txt
             authority = cls._generate_domain(prefix="www", suffix=["com", "org"])
             query = cls._generate_query(use_equal=True)
             fragment = RandomString.generate()
             return f"{schema.value}://{authority}?{query}#{fragment}"
-        elif schema is URISchema.File:
+        elif schema is URIScheme.File:
             # ex: file://username/wow/Download/test.txt
             path = cls._generate_file_path(only_file=False)
             return f"{schema.value}://{path}"
-        elif schema is URISchema.FTP:
+        elif schema is URIScheme.FTP:
             # ex: ftp://ftp.is.co.za/rfc/rfc1808.txt
             authority = cls._generate_domain(
                 prefix="ftp", body_size=ValueSize(min=3, max=4), body_ele_size=ValueSize(min=2, max=3)
             )
             path = cls._generate_file_path(only_file=True)
             return f"{schema.value}://{authority}/{path}"
-        elif schema is URISchema.Mail_To:
+        elif schema is URIScheme.Mail_To:
             # ex: mailto:John.Doe@example.com
             return f"{schema.value}://{RandomEMail.generate()}"
-        elif schema is URISchema.LDAP:
+        elif schema is URIScheme.LDAP:
             # ex: ldap://[2001:db8::7]/c=GB?objectClass?one
             authority = cls._generate_domain(prefix="ldap")
             path = "c=GB"
             query = cls._generate_query(use_equal=False)
             return f"{schema.value}://{authority}/{path}?{query}"
-        elif schema is URISchema.NEWS:
+        elif schema is URIScheme.NEWS:
             # ex: news:comp.infosystems.www.servers.unix
             path = cls._generate_domain(prefix="www", suffix=["com"], reverse=True)
             return f"{schema.value}://{path}.servers.unix"
-        elif schema is URISchema.TEL:
+        elif schema is URIScheme.TEL:
             # ex: tel:+1-816-555-1212
             path = cls._generate_phone_number()
             return f"{schema.value}:{path}"
-        elif schema is URISchema.TELNET:
+        elif schema is URIScheme.TELNET:
             # ex: telnet://192.0.2.16:80/
             ip_address = cls._generate_ip_address(version=IPVersion.IPv4)
             port = RandomInteger.generate(value_range=ValueSize(min=10, max=10000))
             authority = f"{ip_address}:{port}"
             return f"{schema.value}://{authority}/"
-        elif schema is URISchema.URN:
+        elif schema is URIScheme.URN:
             # ex: urn:oasis:names:specification:docbook:dtd:xml:4.1.2
             path = cls._generate_urn()
             return f"{schema.value}:{path}"

--- a/pymock_server/_utils/random.py
+++ b/pymock_server/_utils/random.py
@@ -126,57 +126,57 @@ class RandomIP(BaseRandomGenerator):
 
 class RandomURI(BaseRandomGenerator):
     @classmethod
-    def generate(cls, schema: URIScheme = URIScheme.HTTPS) -> str:
-        return cls._generate_uri_by_schema(schema)
+    def generate(cls, scheme: URIScheme = URIScheme.HTTPS) -> str:
+        return cls._generate_uri_by_schema(scheme)
 
     @classmethod
-    def _generate_uri_by_schema(cls, schema: URIScheme) -> str:
-        if schema in (URIScheme.HTTP, URIScheme.HTTPS):
+    def _generate_uri_by_schema(cls, scheme: URIScheme) -> str:
+        if scheme in (URIScheme.HTTP, URIScheme.HTTPS):
             # ex: http://www.ietf.org/rfc/rfc2396.txt
             authority = cls._generate_domain(prefix="www", suffix=["com", "org"])
             query = cls._generate_query(use_equal=True)
             fragment = RandomString.generate()
-            return f"{schema.value}://{authority}?{query}#{fragment}"
-        elif schema is URIScheme.File:
+            return f"{scheme.value}://{authority}?{query}#{fragment}"
+        elif scheme is URIScheme.File:
             # ex: file://username/wow/Download/test.txt
             path = cls._generate_file_path(only_file=False)
-            return f"{schema.value}://{path}"
-        elif schema is URIScheme.FTP:
+            return f"{scheme.value}://{path}"
+        elif scheme is URIScheme.FTP:
             # ex: ftp://ftp.is.co.za/rfc/rfc1808.txt
             authority = cls._generate_domain(
                 prefix="ftp", body_size=ValueSize(min=3, max=4), body_ele_size=ValueSize(min=2, max=3)
             )
             path = cls._generate_file_path(only_file=True)
-            return f"{schema.value}://{authority}/{path}"
-        elif schema is URIScheme.Mail_To:
+            return f"{scheme.value}://{authority}/{path}"
+        elif scheme is URIScheme.Mail_To:
             # ex: mailto:John.Doe@example.com
-            return f"{schema.value}://{RandomEMail.generate()}"
-        elif schema is URIScheme.LDAP:
+            return f"{scheme.value}://{RandomEMail.generate()}"
+        elif scheme is URIScheme.LDAP:
             # ex: ldap://[2001:db8::7]/c=GB?objectClass?one
             authority = cls._generate_domain(prefix="ldap")
             path = "c=GB"
             query = cls._generate_query(use_equal=False)
-            return f"{schema.value}://{authority}/{path}?{query}"
-        elif schema is URIScheme.NEWS:
+            return f"{scheme.value}://{authority}/{path}?{query}"
+        elif scheme is URIScheme.NEWS:
             # ex: news:comp.infosystems.www.servers.unix
             path = cls._generate_domain(prefix="www", suffix=["com"], reverse=True)
-            return f"{schema.value}://{path}.servers.unix"
-        elif schema is URIScheme.TEL:
+            return f"{scheme.value}://{path}.servers.unix"
+        elif scheme is URIScheme.TEL:
             # ex: tel:+1-816-555-1212
             path = cls._generate_phone_number()
-            return f"{schema.value}:{path}"
-        elif schema is URIScheme.TELNET:
+            return f"{scheme.value}:{path}"
+        elif scheme is URIScheme.TELNET:
             # ex: telnet://192.0.2.16:80/
             ip_address = cls._generate_ip_address(version=IPVersion.IPv4)
             port = RandomInteger.generate(value_range=ValueSize(min=10, max=10000))
             authority = f"{ip_address}:{port}"
-            return f"{schema.value}://{authority}/"
-        elif schema is URIScheme.URN:
+            return f"{scheme.value}://{authority}/"
+        elif scheme is URIScheme.URN:
             # ex: urn:oasis:names:specification:docbook:dtd:xml:4.1.2
             path = cls._generate_urn()
-            return f"{schema.value}:{path}"
+            return f"{scheme.value}:{path}"
         else:
-            raise ValueError(f"Not support generate the URI with schema *{schema}*.")
+            raise ValueError(f"Not support generate the URI with scheme *{scheme}*.")
 
     @classmethod
     def _generate_domain(

--- a/pymock_server/_utils/random.py
+++ b/pymock_server/_utils/random.py
@@ -127,10 +127,10 @@ class RandomIP(BaseRandomGenerator):
 class RandomURI(BaseRandomGenerator):
     @classmethod
     def generate(cls, scheme: URIScheme = URIScheme.HTTPS) -> str:
-        return cls._generate_uri_by_schema(scheme)
+        return cls._generate_uri_by_scheme(scheme)
 
     @classmethod
-    def _generate_uri_by_schema(cls, scheme: URIScheme) -> str:
+    def _generate_uri_by_scheme(cls, scheme: URIScheme) -> str:
         if scheme in (URIScheme.HTTP, URIScheme.HTTPS):
             # ex: http://www.ietf.org/rfc/rfc2396.txt
             authority = cls._generate_domain(prefix="www", suffix=["com", "org"])

--- a/pymock_server/_utils/uri_protocol.py
+++ b/pymock_server/_utils/uri_protocol.py
@@ -46,7 +46,7 @@ class URIScheme(Enum):
         elif self is URIScheme.URN:
             return r"urn:(\w{1,24}|:){1,7}"
         else:
-            raise ValueError(f"Not support generate the URI with schema *{self}*.")
+            raise ValueError(f"Not support generate the URI with scheme *{self}*.")
 
 
 class IPVersion(Enum):

--- a/pymock_server/_utils/uri_protocol.py
+++ b/pymock_server/_utils/uri_protocol.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import Union
 
 
-class URISchema(Enum):
+class URIScheme(Enum):
     HTTP: str = "http"
     HTTPS: str = "https"
     File: str = "file"
@@ -15,35 +15,35 @@ class URISchema(Enum):
     URN: str = "urn"
 
     @staticmethod
-    def to_enum(v: Union[str, "URISchema"]):
-        if isinstance(v, URISchema):
+    def to_enum(v: Union[str, "URIScheme"]):
+        if isinstance(v, URIScheme):
             return v
         else:
-            for schema in URISchema:
+            for schema in URIScheme:
                 if schema.value.lower() == str(v).lower():
                     return schema
             raise ValueError(f"Cannot find the URI schema '{v}'.")
 
     def generate_value_regex(self) -> str:
-        if self is URISchema.HTTP:
+        if self is URIScheme.HTTP:
             return r"http://www\.(\w{1,24}|\.){1,7}\.(com|org)"
-        elif self is URISchema.HTTPS:
+        elif self is URIScheme.HTTPS:
             return r"https://www\.(\w{1,24}|\.){1,7}\.(com|org)"
-        elif self is URISchema.File:
+        elif self is URIScheme.File:
             return r"file://(\w{1,10}|/){1,11}\.(jpg|jpeg|png|text|txt|py|md)"
-        elif self is URISchema.FTP:
+        elif self is URIScheme.FTP:
             return r"ftp://ftp\.(\w{2,3}|\.){5,7}/(\w{1,10}|/){1,3}\.(jpg|jpeg|png|text|txt|py|md)"
-        elif self is URISchema.Mail_To:
+        elif self is URIScheme.Mail_To:
             return r"mailto://\w{1,124}@(gmail|outlook|yahoo).com"
-        elif self is URISchema.LDAP:
+        elif self is URIScheme.LDAP:
             return r"ldap://ldap\.(\w{1,24}|\.){1,7}/c=GB"
-        elif self is URISchema.NEWS:
+        elif self is URIScheme.NEWS:
             return r"news://com\.(\w{1,24}|\.){1,7}\.www.servers.unix"
-        elif self is URISchema.TEL:
+        elif self is URIScheme.TEL:
             return r"tel:\+1-886-\d{3}-\d{4}"
-        elif self is URISchema.TELNET:
+        elif self is URIScheme.TELNET:
             return r"telnet://\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}:\d{2,4}/"
-        elif self is URISchema.URN:
+        elif self is URIScheme.URN:
             return r"urn:(\w{1,24}|:){1,7}"
         else:
             raise ValueError(f"Not support generate the URI with schema *{self}*.")

--- a/pymock_server/_utils/uri_protocol.py
+++ b/pymock_server/_utils/uri_protocol.py
@@ -22,7 +22,7 @@ class URIScheme(Enum):
             for schema in URIScheme:
                 if schema.value.lower() == str(v).lower():
                     return schema
-            raise ValueError(f"Cannot find the URI schema '{v}'.")
+            raise ValueError(f"Cannot find the URI scheme '{v}'.")
 
     def generate_value_regex(self) -> str:
         if self is URIScheme.HTTP:

--- a/pymock_server/model/api_config/value.py
+++ b/pymock_server/model/api_config/value.py
@@ -107,7 +107,7 @@ class ValueFormat(Enum):
         elif self is ValueFormat.UUID:
             return RandomUUID.generate()
         elif self is ValueFormat.URI:
-            # TODO: It should has setting to configure URI schema
+            # TODO: It should has setting to configure URI scheme
             return RandomURI.generate(scheme=URIScheme.HTTPS)
         elif self is ValueFormat.URL:
             return RandomURI.generate(scheme=URIScheme.HTTPS)
@@ -149,7 +149,7 @@ class ValueFormat(Enum):
         elif self is ValueFormat.UUID:
             return r"\w{8}-\w{4}-\w{4}-\w{4}-\w{12}"
         elif self is ValueFormat.URI:
-            # TODO: It should has setting to configure URI schema
+            # TODO: It should has setting to configure URI scheme
             return URIScheme.HTTPS.generate_value_regex()
         elif self is ValueFormat.URL:
             return URIScheme.HTTPS.generate_value_regex()

--- a/pymock_server/model/api_config/value.py
+++ b/pymock_server/model/api_config/value.py
@@ -18,7 +18,7 @@ from pymock_server._utils.random import (
     RandomUUID,
     ValueSize,
 )
-from pymock_server._utils.uri_protocol import IPVersion, URISchema
+from pymock_server._utils.uri_protocol import IPVersion, URIScheme
 
 Default_Value_Size = ValueSize(max=10, min=1)
 Default_Digit_Range = DigitRange(integer=128, decimal=128)
@@ -108,9 +108,9 @@ class ValueFormat(Enum):
             return RandomUUID.generate()
         elif self is ValueFormat.URI:
             # TODO: It should has setting to configure URI schema
-            return RandomURI.generate(schema=URISchema.HTTPS)
+            return RandomURI.generate(schema=URIScheme.HTTPS)
         elif self is ValueFormat.URL:
-            return RandomURI.generate(schema=URISchema.HTTPS)
+            return RandomURI.generate(schema=URIScheme.HTTPS)
         elif self is ValueFormat.IPv4:
             return RandomIP.generate(IPVersion.IPv4)
         elif self is ValueFormat.IPv6:
@@ -150,9 +150,9 @@ class ValueFormat(Enum):
             return r"\w{8}-\w{4}-\w{4}-\w{4}-\w{12}"
         elif self is ValueFormat.URI:
             # TODO: It should has setting to configure URI schema
-            return URISchema.HTTPS.generate_value_regex()
+            return URIScheme.HTTPS.generate_value_regex()
         elif self is ValueFormat.URL:
-            return URISchema.HTTPS.generate_value_regex()
+            return URIScheme.HTTPS.generate_value_regex()
         elif self is ValueFormat.IPv4:
             return r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}"
         elif self is ValueFormat.IPv6:

--- a/pymock_server/model/api_config/value.py
+++ b/pymock_server/model/api_config/value.py
@@ -108,9 +108,9 @@ class ValueFormat(Enum):
             return RandomUUID.generate()
         elif self is ValueFormat.URI:
             # TODO: It should has setting to configure URI schema
-            return RandomURI.generate(schema=URIScheme.HTTPS)
+            return RandomURI.generate(scheme=URIScheme.HTTPS)
         elif self is ValueFormat.URL:
-            return RandomURI.generate(schema=URIScheme.HTTPS)
+            return RandomURI.generate(scheme=URIScheme.HTTPS)
         elif self is ValueFormat.IPv4:
             return RandomIP.generate(IPVersion.IPv4)
         elif self is ValueFormat.IPv6:

--- a/test/unit_test/_utils/random.py
+++ b/test/unit_test/_utils/random.py
@@ -20,7 +20,7 @@ from pymock_server._utils.random import (
     RandomURI,
     RandomUUID,
 )
-from pymock_server._utils.uri_protocol import IPVersion, URISchema
+from pymock_server._utils.uri_protocol import IPVersion, URIScheme
 
 logger = logging.getLogger(__name__)
 
@@ -108,8 +108,8 @@ class TestRandomURI(BaseRandomGeneratorTestSuite):
     def generator(self) -> Type[RandomURI]:
         return RandomURI
 
-    @pytest.mark.parametrize("schema", [s for s in URISchema])
-    def test_generate(self, generator: Type[RandomURI], schema: URISchema) -> None:
+    @pytest.mark.parametrize("schema", [s for s in URIScheme])
+    def test_generate(self, generator: Type[RandomURI], schema: URIScheme) -> None:
         random_uri = generator.generate(schema)
         logger.info(f"The random URI value is: {random_uri}")
         expect_regex = schema.generate_value_regex()

--- a/test/unit_test/_utils/random.py
+++ b/test/unit_test/_utils/random.py
@@ -108,16 +108,16 @@ class TestRandomURI(BaseRandomGeneratorTestSuite):
     def generator(self) -> Type[RandomURI]:
         return RandomURI
 
-    @pytest.mark.parametrize("schema", [s for s in URIScheme])
-    def test_generate(self, generator: Type[RandomURI], schema: URIScheme) -> None:
-        random_uri = generator.generate(schema)
+    @pytest.mark.parametrize("scheme", [s for s in URIScheme])
+    def test_generate(self, generator: Type[RandomURI], scheme: URIScheme) -> None:
+        random_uri = generator.generate(scheme)
         logger.info(f"The random URI value is: {random_uri}")
-        expect_regex = schema.generate_value_regex()
+        expect_regex = scheme.generate_value_regex()
         assert re.search(expect_regex, random_uri)
 
-    def test_generate_with_invalid_schema(self, generator: RandomURI):
+    def test_generate_with_invalid_scheme(self, generator: RandomURI):
         with pytest.raises(ValueError):
-            generator.generate(scheme="invalid URI schema")
+            generator.generate(scheme="invalid URI scheme")
 
 
 class TestRandomIP(BaseRandomGeneratorTestSuite):

--- a/test/unit_test/_utils/random.py
+++ b/test/unit_test/_utils/random.py
@@ -117,7 +117,7 @@ class TestRandomURI(BaseRandomGeneratorTestSuite):
 
     def test_generate_with_invalid_schema(self, generator: RandomURI):
         with pytest.raises(ValueError):
-            generator.generate(schema="invalid URI schema")
+            generator.generate(scheme="invalid URI schema")
 
 
 class TestRandomIP(BaseRandomGeneratorTestSuite):

--- a/test/unit_test/_utils/uri_protocol.py
+++ b/test/unit_test/_utils/uri_protocol.py
@@ -11,7 +11,7 @@ _Test_Data.extend(uri_enum)
 _Test_Data.extend(uri_enum_value)
 
 
-class TestURISchema:
+class TestURIScheme:
     @pytest.mark.parametrize(("value", "expected"), _Test_Data)
     def test_to_enum(self, value: Union[str, URIScheme], expected: URIScheme) -> None:
         assert URIScheme.to_enum(value) is expected

--- a/test/unit_test/_utils/uri_protocol.py
+++ b/test/unit_test/_utils/uri_protocol.py
@@ -2,39 +2,39 @@ from typing import List, Tuple, Union
 
 import pytest
 
-from pymock_server._utils.uri_protocol import URISchema
+from pymock_server._utils.uri_protocol import URIScheme
 
-_Test_Data: List[Tuple[Union[str, URISchema], str]] = []
-uri_enum = [(uri, uri) for uri in URISchema]
-uri_enum_value = [(uri.value, uri) for uri in URISchema]
+_Test_Data: List[Tuple[Union[str, URIScheme], str]] = []
+uri_enum = [(uri, uri) for uri in URIScheme]
+uri_enum_value = [(uri.value, uri) for uri in URIScheme]
 _Test_Data.extend(uri_enum)
 _Test_Data.extend(uri_enum_value)
 
 
 class TestURISchema:
     @pytest.mark.parametrize(("value", "expected"), _Test_Data)
-    def test_to_enum(self, value: Union[str, URISchema], expected: URISchema) -> None:
-        assert URISchema.to_enum(value) is expected
+    def test_to_enum(self, value: Union[str, URIScheme], expected: URIScheme) -> None:
+        assert URIScheme.to_enum(value) is expected
 
     def test_to_enum_with_invalid(self):
         with pytest.raises(ValueError):
-            URISchema.to_enum("invalid value")
+            URIScheme.to_enum("invalid value")
 
     @pytest.mark.parametrize(
         ("schema", "expect_regex"),
         [
-            (URISchema.HTTP, r"http://www\.(\w{1,24}|\.){1,7}\.(com|org)"),
-            (URISchema.HTTPS, r"https://www\.(\w{1,24}|\.){1,7}\.(com|org)"),
-            (URISchema.File, r"file://(\w{1,10}|/){1,11}\.(jpg|jpeg|png|text|txt|py|md)"),
-            (URISchema.FTP, r"ftp://ftp\.(\w{2,3}|\.){5,7}/(\w{1,10}|/){1,3}\.(jpg|jpeg|png|text|txt|py|md)"),
-            (URISchema.Mail_To, r"mailto://\w{1,124}@(gmail|outlook|yahoo).com"),
-            (URISchema.LDAP, r"ldap://ldap\.(\w{1,24}|\.){1,7}/c=GB"),
-            (URISchema.NEWS, r"news://com\.(\w{1,24}|\.){1,7}\.www.servers.unix"),
-            (URISchema.TEL, r"tel:\+1-886-\d{3}-\d{4}"),
-            (URISchema.TELNET, r"telnet://\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}:\d{2,4}/"),
-            (URISchema.URN, r"urn:(\w{1,24}|:){1,7}"),
+            (URIScheme.HTTP, r"http://www\.(\w{1,24}|\.){1,7}\.(com|org)"),
+            (URIScheme.HTTPS, r"https://www\.(\w{1,24}|\.){1,7}\.(com|org)"),
+            (URIScheme.File, r"file://(\w{1,10}|/){1,11}\.(jpg|jpeg|png|text|txt|py|md)"),
+            (URIScheme.FTP, r"ftp://ftp\.(\w{2,3}|\.){5,7}/(\w{1,10}|/){1,3}\.(jpg|jpeg|png|text|txt|py|md)"),
+            (URIScheme.Mail_To, r"mailto://\w{1,124}@(gmail|outlook|yahoo).com"),
+            (URIScheme.LDAP, r"ldap://ldap\.(\w{1,24}|\.){1,7}/c=GB"),
+            (URIScheme.NEWS, r"news://com\.(\w{1,24}|\.){1,7}\.www.servers.unix"),
+            (URIScheme.TEL, r"tel:\+1-886-\d{3}-\d{4}"),
+            (URIScheme.TELNET, r"telnet://\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}:\d{2,4}/"),
+            (URIScheme.URN, r"urn:(\w{1,24}|:){1,7}"),
         ],
     )
-    def test_generate_value_regex(self, schema: URISchema, expect_regex: str) -> None:
+    def test_generate_value_regex(self, schema: URIScheme, expect_regex: str) -> None:
         random_uri_regex = schema.generate_value_regex()
         assert expect_regex == random_uri_regex


### PR DESCRIPTION
### _Target_

* Rename the data model about URI scheme to be correct (refer RFC).
* Task ticket: [CU-86er1mm6d](https://app.clickup.com/t/86er1mm6d)
* Reference:
    * [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986#page-17)
    * <img width="851" alt="rfc3986_screenshot" src="https://github.com/user-attachments/assets/709025fd-4905-4782-b927-c9010af22648" />



### _Effecting Scope_

* No any breaking changes.


### _Description_

* Rename all naming at anywhere includes functions, variables, etc. or something else as correct naming about URI scheme.
