### PR TITLE
[CU-86er1h8zm] Add more tests to cover the issue about converting incorrect between API document config and PyMock-Server config.

### DIFF
--- a/test/integration_test/model/rest_api_doc_config/config.py
+++ b/test/integration_test/model/rest_api_doc_config/config.py
@@ -1,0 +1,133 @@
+import logging
+from abc import ABCMeta, abstractmethod
+from http import HTTPStatus
+from typing import Any, Dict
+
+import pytest
+
+from pymock_server.model import OpenAPIVersion
+from pymock_server.model.rest_api_doc_config._base import set_openapi_version
+from pymock_server.model.rest_api_doc_config.base_config import (
+    _BaseAPIConfigWithMethod,
+    set_component_definition,
+)
+from pymock_server.model.rest_api_doc_config.config import (
+    APIConfigWithMethodV2,
+    APIConfigWithMethodV3,
+    HttpConfigV2,
+    HttpConfigV3,
+    ReferenceConfigProperty,
+)
+from pymock_server.model.rest_api_doc_config.content_type import ContentType
+
+logger = logging.getLogger(__name__)
+
+
+_Common_Schemas: Dict[str, Dict] = {
+    "schemas": {
+        # For int64 format value
+        "Int64FormatResponse": {
+            "type": "object",
+            "required": ["value"],
+            "properties": {
+                "value": {"type": "integer", "format": "int64"},
+            },
+            "title": "FooResponse",
+        },
+        # For string value with enums
+        "EnumsFormatResponse": {
+            "type": "object",
+            "required": ["value"],
+            "properties": {
+                "value": {"type": "string", "enum": ["TYPE_1", "TYPE_2"]},
+            },
+            "title": "FooResponse",
+        },
+        # For array value with format element
+        "FormatElementArrayResponse": {
+            "type": "object",
+            "required": ["value"],
+            "properties": {
+                "value": {"type": "array", "items": {"type": "integer", "format": "int64"}},
+            },
+            "title": "FooResponse",
+        },
+    },
+}
+
+
+class ApiDocConfigToPyMockAPIConfigAtHTTPResponseValueFormatTestSuite(metaclass=ABCMeta):
+    @pytest.mark.parametrize(
+        ("api_doc_config", "format_in_array"),
+        [
+            ({"$ref": "#/components/schemas/Int64FormatResponse"}, False),
+            ({"$ref": "#/components/schemas/EnumsFormatResponse"}, False),
+            ({"$ref": "#/components/schemas/FormatElementArrayResponse"}, True),
+        ],
+    )
+    def test_convert_api_doc_config_to_adapter_to_pymock_config(
+        self, api_doc_config: Dict[str, Any], format_in_array: bool
+    ):
+        """
+        Test goal: value converting workflow at specific column *value_format*
+        API document config -> adapter -> PyMock-Server config
+        """
+        # given
+        set_openapi_version(self._api_doc_version)
+        set_component_definition(_Common_Schemas)
+        api_doc_http_config = self._set_response(api_doc_config)
+
+        # when
+        response_config_adapter = api_doc_http_config.to_responses_adapter()
+        response_configs = [ra.to_pymock_api_config() for ra in response_config_adapter.data]
+
+        # should
+        one_resp_configs = response_configs[0]
+        if format_in_array:
+            assert one_resp_configs.items
+            assert one_resp_configs.items[0].value_format is not None
+        else:
+            assert one_resp_configs.value_format is not None
+
+    @property
+    @abstractmethod
+    def _api_doc_version(self) -> OpenAPIVersion:
+        pass
+
+    @abstractmethod
+    def _set_response(self, api_doc_config: Dict[str, Any]) -> _BaseAPIConfigWithMethod:
+        pass
+
+
+class TestAPIConfigWithMethodV2(ApiDocConfigToPyMockAPIConfigAtHTTPResponseValueFormatTestSuite):
+
+    @property
+    def _api_doc_version(self) -> OpenAPIVersion:
+        return OpenAPIVersion.V2
+
+    def _set_response(self, api_doc_config: Dict[str, Any]) -> APIConfigWithMethodV2:
+        return APIConfigWithMethodV2(
+            responses={
+                HTTPStatus.OK: HttpConfigV2(schema=ReferenceConfigProperty().deserialize(api_doc_config)),
+            },
+        )
+
+
+class TestAPIConfigWithMethodV3(ApiDocConfigToPyMockAPIConfigAtHTTPResponseValueFormatTestSuite):
+
+    @property
+    def _api_doc_version(self) -> OpenAPIVersion:
+        return OpenAPIVersion.V3
+
+    def _set_response(self, api_doc_config: Dict[str, Any]) -> APIConfigWithMethodV3:
+        return APIConfigWithMethodV3(
+            responses={
+                HTTPStatus.OK: HttpConfigV3(
+                    content={
+                        ContentType.APPLICATION_JSON: HttpConfigV2(
+                            schema=ReferenceConfigProperty().deserialize(api_doc_config)
+                        ),
+                    }
+                ),
+            },
+        )

--- a/test/integration_test/model/rest_api_doc_config/config.py
+++ b/test/integration_test/model/rest_api_doc_config/config.py
@@ -45,6 +45,15 @@ _Common_Schemas: Dict[str, Dict] = {
             },
             "title": "EnumsFormatResponse",
         },
+        # For URI format string value
+        "UriFormatResponse": {
+            "type": "object",
+            "required": [_COLUMN_NAME],
+            "properties": {
+                _COLUMN_NAME: {"type": "integer", "format": "uri"},
+            },
+            "title": "UriFormatResponse",
+        },
         # For array value with format element
         "FormatElementArrayResponse": {
             "type": "object",
@@ -64,6 +73,7 @@ class ApiDocConfigToPyMockAPIConfigAtHTTPResponseValueFormatTestSuite(metaclass=
         [
             ({"$ref": "#/components/schemas/Int64FormatResponse"}, FormatStrategy.BY_DATA_TYPE, False),
             ({"$ref": "#/components/schemas/EnumsFormatResponse"}, FormatStrategy.FROM_ENUMS, False),
+            ({"$ref": "#/components/schemas/UriFormatResponse"}, FormatStrategy.CUSTOMIZE, False),
             ({"$ref": "#/components/schemas/FormatElementArrayResponse"}, FormatStrategy.BY_DATA_TYPE, True),
         ],
     )

--- a/test/integration_test/model/rest_api_doc_config/config.py
+++ b/test/integration_test/model/rest_api_doc_config/config.py
@@ -67,7 +67,7 @@ _Common_Schemas: Dict[str, Dict] = {
 }
 
 
-class ApiDocConfigToPyMockAPIConfigAtHTTPResponseValueFormatTestSuite(metaclass=ABCMeta):
+class ConvertApiDocConfigToPyMockAPIConfigAtHTTPResponseTestSuite(metaclass=ABCMeta):
     @pytest.mark.parametrize(
         ("api_doc_config", "format_strategy", "format_in_array"),
         [
@@ -123,7 +123,7 @@ class ApiDocConfigToPyMockAPIConfigAtHTTPResponseValueFormatTestSuite(metaclass=
         pass
 
 
-class TestAPIConfigWithMethodV2(ApiDocConfigToPyMockAPIConfigAtHTTPResponseValueFormatTestSuite):
+class TestAPIConfigWithMethodV2(ConvertApiDocConfigToPyMockAPIConfigAtHTTPResponseTestSuite):
 
     @property
     def _api_doc_version(self) -> OpenAPIVersion:
@@ -137,7 +137,7 @@ class TestAPIConfigWithMethodV2(ApiDocConfigToPyMockAPIConfigAtHTTPResponseValue
         )
 
 
-class TestAPIConfigWithMethodV3(ApiDocConfigToPyMockAPIConfigAtHTTPResponseValueFormatTestSuite):
+class TestAPIConfigWithMethodV3(ConvertApiDocConfigToPyMockAPIConfigAtHTTPResponseTestSuite):
 
     @property
     def _api_doc_version(self) -> OpenAPIVersion:

--- a/test/unit_test/model/rest_api_doc_config/_base_config.py
+++ b/test/unit_test/model/rest_api_doc_config/_base_config.py
@@ -129,6 +129,44 @@ class BaseAPIDocConfigTestSuite(metaclass=ABCMeta):
                 {"type": "file"},
                 {"name": "", "required": True, "type": "file"},
             ),
+            # For object strategy with format
+            (
+                # 1
+                {"type": "integer", "format": "int64"},
+                {
+                    "name": "",
+                    "required": True,
+                    "type": "int",
+                    "value_format": {
+                        "strategy": "by_data_type",
+                        "size": {"max": 9223372036854775807, "min": -9223372036854775808},
+                    },
+                },
+            ),
+            (
+                # 2
+                {"type": "string", "enum": ["TYPE_1", "TYPE_2"]},
+                {
+                    "name": "",
+                    "required": True,
+                    "type": "str",
+                    "value_format": {"strategy": "from_enums", "enums": ["TYPE_1", "TYPE_2"]},
+                },
+            ),
+            (
+                # 3
+                {"type": "string", "format": "uri"},
+                {
+                    "name": "",
+                    "required": True,
+                    "type": "str",
+                    "value_format": {
+                        "strategy": "customize",
+                        "customize": "uri_value",
+                        "variables": [{"name": "uri_value", "value_format": "uri"}],
+                    },
+                },
+            ),
             # # Special data
             (
                 # 7

--- a/test/unit_test/model/rest_api_doc_config/_base_config.py
+++ b/test/unit_test/model/rest_api_doc_config/_base_config.py
@@ -77,22 +77,22 @@ class BaseAPIDocConfigTestSuite(metaclass=ABCMeta):
             # # # General data
             # For object strategy
             (
-                # 1
+                # 0
                 {"type": "integer"},
                 {"name": "", "required": True, "type": "int"},
             ),
             (
-                # 2
+                # 1
                 {"type": "number"},
                 {"name": "", "required": True, "type": "int"},
             ),
             (
-                # 3
+                # 2
                 {"type": "boolean"},
                 {"name": "", "required": True, "type": "bool"},
             ),
             (
-                # 4
+                # 3
                 {"type": "array", "items": {"type": "integer"}},
                 {
                     "name": "",
@@ -102,7 +102,7 @@ class BaseAPIDocConfigTestSuite(metaclass=ABCMeta):
                 },
             ),
             (
-                # 5
+                # 4
                 {"type": "array", "items": {"$ref": "#/components/schemas/FooResponse"}},
                 {
                     "name": "",
@@ -125,13 +125,13 @@ class BaseAPIDocConfigTestSuite(metaclass=ABCMeta):
                 },
             ),
             (
-                # 6
+                # 5
                 {"type": "file"},
                 {"name": "", "required": True, "type": "file"},
             ),
             # For object strategy with format
             (
-                # 1
+                # 6
                 {"type": "integer", "format": "int64"},
                 {
                     "name": "",
@@ -144,7 +144,7 @@ class BaseAPIDocConfigTestSuite(metaclass=ABCMeta):
                 },
             ),
             (
-                # 2
+                # 7
                 {"type": "string", "enum": ["TYPE_1", "TYPE_2"]},
                 {
                     "name": "",
@@ -154,7 +154,7 @@ class BaseAPIDocConfigTestSuite(metaclass=ABCMeta):
                 },
             ),
             (
-                # 3
+                # 8
                 {"type": "string", "format": "uri"},
                 {
                     "name": "",
@@ -169,7 +169,7 @@ class BaseAPIDocConfigTestSuite(metaclass=ABCMeta):
             ),
             # # Special data
             (
-                # 7
+                # 9
                 {
                     "type": "object",
                     "additionalProperties": {
@@ -184,7 +184,7 @@ class BaseAPIDocConfigTestSuite(metaclass=ABCMeta):
                 },
             ),
             (
-                # 8
+                # 10
                 {
                     "type": "object",
                     "additionalProperties": {
@@ -207,7 +207,7 @@ class BaseAPIDocConfigTestSuite(metaclass=ABCMeta):
                 },
             ),
             (
-                # 9
+                # 11
                 {
                     "type": "object",
                     "additionalProperties": {
@@ -235,7 +235,7 @@ class BaseAPIDocConfigTestSuite(metaclass=ABCMeta):
                 },
             ),
             (
-                # 10
+                # 12
                 {
                     "type": "object",
                     "additionalProperties": {
@@ -314,7 +314,7 @@ class BaseAPIDocConfigTestSuite(metaclass=ABCMeta):
                 },
             ),
             (
-                # 11
+                # 13
                 {
                     "$ref": "#/components/schemas/NestedFooResponse",
                 },


### PR DESCRIPTION
### _Target_

* Add more tests to cover the issue about converting incorrect between API document config and PyMock-Server config.
* Task ticket: [CU-86er1h8zm](https://app.clickup.com/t/86er1h8zm)


### _Effecting Scope_

* No any breaking changes.


### _Description_

* Add unit tests about generating response adapter model from API document configuration which has value format setting.
* Add integration tests which target to cover the converting feature between API document configuration and PyMock-Server configuration.
