### PR TITLE
[CU-86er3ath9] Fix the incorrect value converting logic at value format feature from adapter to PyMock-Server config 

### DIFF
--- a/pymock_server/model/api_config/format.py
+++ b/pymock_server/model/api_config/format.py
@@ -328,8 +328,7 @@ class _HasFormatPropConfig(_BaseConfig, _Checkable, ABC):
 
     @_Config._ensure_process_with_not_empty_value
     def deserialize(self, data: Dict[str, Any]) -> Optional["_HasFormatPropConfig"]:
-        # FIXME: the adapter model's serialization is using property *value_format*. This is an issue needs to fix.
-        col_format = data.get("format", None) or data.get("value_format", None)
+        col_format = data.get("format", None)
         if col_format is not None:
             col_format = Format().deserialize(col_format)
         self.value_format = col_format

--- a/pymock_server/model/rest_api_doc_config/_base_model_adapter.py
+++ b/pymock_server/model/rest_api_doc_config/_base_model_adapter.py
@@ -59,7 +59,7 @@ class BasePropertyDetailAdapter(metaclass=ABCMeta):
             "name": self.name,
             "required": self.required,
             "type": self.value_type,
-            "value_format": _format_params,
+            "format": _format_params,
             "items": [item.serialize() for item in self.items] if self.items else None,
         }
         return self._clear_empty_values(data)

--- a/test/unit_test/model/rest_api_doc_config/_base_config.py
+++ b/test/unit_test/model/rest_api_doc_config/_base_config.py
@@ -121,7 +121,7 @@ class BaseAPIDocConfigTestSuite(metaclass=ABCMeta):
                             "name": "id",
                             "required": True,
                             "type": "int",
-                            "value_format": {
+                            "format": {
                                 "strategy": "by_data_type",
                                 "size": {"max": 9223372036854775807, "min": -9223372036854775808},
                             },
@@ -145,7 +145,7 @@ class BaseAPIDocConfigTestSuite(metaclass=ABCMeta):
                     "name": "",
                     "required": True,
                     "type": "int",
-                    "value_format": {
+                    "format": {
                         "strategy": "by_data_type",
                         "size": {"max": 9223372036854775807, "min": -9223372036854775808},
                     },
@@ -158,7 +158,7 @@ class BaseAPIDocConfigTestSuite(metaclass=ABCMeta):
                     "name": "",
                     "required": True,
                     "type": "str",
-                    "value_format": {"strategy": "from_enums", "enums": ["TYPE_1", "TYPE_2"]},
+                    "format": {"strategy": "from_enums", "enums": ["TYPE_1", "TYPE_2"]},
                 },
             ),
             (
@@ -168,7 +168,7 @@ class BaseAPIDocConfigTestSuite(metaclass=ABCMeta):
                     "name": "",
                     "required": True,
                     "type": "str",
-                    "value_format": {
+                    "format": {
                         "strategy": "customize",
                         "customize": "uri_value",
                         "variables": [{"name": "uri_value", "value_format": "uri"}],
@@ -209,7 +209,7 @@ class BaseAPIDocConfigTestSuite(metaclass=ABCMeta):
                             "name": "",
                             "required": True,
                             "type": "str",
-                            "value_format": {"strategy": "from_enums", "enums": ["TYPE_1", "TYPE_2"]},
+                            "format": {"strategy": "from_enums", "enums": ["TYPE_1", "TYPE_2"]},
                         },
                     ],
                 },
@@ -231,7 +231,7 @@ class BaseAPIDocConfigTestSuite(metaclass=ABCMeta):
                             "name": "id",
                             "required": True,
                             "type": "int",
-                            "value_format": {
+                            "format": {
                                 "strategy": "by_data_type",
                                 "size": {"max": 9223372036854775807, "min": -9223372036854775808},
                             },
@@ -259,7 +259,7 @@ class BaseAPIDocConfigTestSuite(metaclass=ABCMeta):
                             "name": "id",
                             "required": True,
                             "type": "int",
-                            "value_format": {
+                            "format": {
                                 "strategy": "by_data_type",
                                 "size": {"max": 9223372036854775807, "min": -9223372036854775808},
                             },
@@ -274,7 +274,7 @@ class BaseAPIDocConfigTestSuite(metaclass=ABCMeta):
                                     "name": "id",
                                     "required": True,
                                     "type": "int",
-                                    "value_format": {
+                                    "format": {
                                         "strategy": "by_data_type",
                                         "size": {"max": 9223372036854775807, "min": -9223372036854775808},
                                     },
@@ -284,7 +284,7 @@ class BaseAPIDocConfigTestSuite(metaclass=ABCMeta):
                                     "name": "url",
                                     "required": True,
                                     "type": "str",
-                                    "value_format": {
+                                    "format": {
                                         "strategy": "customize",
                                         "customize": "uri_value",
                                         "variables": [{"name": "uri_value", "value_format": "uri"}],
@@ -331,7 +331,7 @@ class BaseAPIDocConfigTestSuite(metaclass=ABCMeta):
                         "name": "id",
                         "required": True,
                         "type": "int",
-                        "value_format": {
+                        "format": {
                             "strategy": "by_data_type",
                             "size": {"max": 9223372036854775807, "min": -9223372036854775808},
                         },
@@ -346,7 +346,7 @@ class BaseAPIDocConfigTestSuite(metaclass=ABCMeta):
                                 "name": "id",
                                 "required": True,
                                 "type": "int",
-                                "value_format": {
+                                "format": {
                                     "strategy": "by_data_type",
                                     "size": {"max": 9223372036854775807, "min": -9223372036854775808},
                                 },
@@ -356,7 +356,7 @@ class BaseAPIDocConfigTestSuite(metaclass=ABCMeta):
                                 "name": "url",
                                 "required": True,
                                 "type": "str",
-                                "value_format": {
+                                "format": {
                                     "strategy": "customize",
                                     "customize": "uri_value",
                                     "variables": [{"name": "uri_value", "value_format": "uri"}],


### PR DESCRIPTION
### _Target_

* Fix the incorrect value converting logic at value format feature from adapter to PyMock-Server config
* Task ticket: [CU-86er3ath9](https://app.clickup.com/t/86er3ath9)


### _Effecting Scope_

* Fix issue without breaking change.


### _Description_

* Fix the issue about incorrect value converting logic.
* Fix the relative broken tests.
