### PR TITLE
[CU-86er3p8qz] Fix badge about CI state error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI](https://img.shields.io/pypi/v/PyMock-Server?color=%23099cec&amp;label=PyPI&amp;logo=pypi&amp;logoColor=white)](https://pypi.org/project/PyMock-Server)
 [![Release](https://img.shields.io/github/release/Chisanan232/PyMock-Server.svg?label=Release&logo=github)](https://github.com/Chisanan232/PyMock-Server/releases)
-[![CI](https://github.com/Chisanan232/PyMock-Server/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/Chisanan232/PyMock-Server/actions/workflows/ci-cd.yml)
+[![CI](https://github.com/Chisanan232/PyMock-Server/actions/workflows/ci.yaml/badge.svg)](https://github.com/Chisanan232/PyMock-Server/actions/workflows/ci.yaml)
 [![codecov](https://codecov.io/gh/Chisanan232/PyMock-Server/graph/badge.svg?token=r5HJxg9KhN)](https://codecov.io/gh/Chisanan232/PyMock-Server)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/Chisanan232/PyMock-Server/master.svg)](https://results.pre-commit.ci/latest/github/Chisanan232/PyMock-Server/master)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=Chisanan232_PyMock-Server&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=Chisanan232_PyMock-Server)

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,8 +11,8 @@
   <a href="https://github.com/Chisanan232/PyMock-Server/releases">
     <img src="https://img.shields.io/github/release/Chisanan232/PyMock-Server.svg?label=Release&logo=github" alt="GitHub release version">
   </a>
-  <a href="https://github.com/Chisanan232/PyMock-Server/actions/workflows/ci-cd.yml">
-    <img src="https://github.com/Chisanan232/PyMock-Server/actions/workflows/ci-cd.yml/badge.svg" alt="CI/CD status">
+  <a href="https://github.com/Chisanan232/PyMock-Server/actions/workflows/ci.yaml">
+    <img src="https://github.com/Chisanan232/PyMock-Server/actions/workflows/ci.yaml/badge.svg" alt="CI/CD status">
   </a>
   <a href="https://codecov.io/gh/Chisanan232/PyMock-Server">
     <img src="https://codecov.io/gh/Chisanan232/PyMock-Server/graph/badge.svg?token=r5HJxg9KhN" alt="Test coverage">


### PR DESCRIPTION
### _Target_

* Fix badge about CI state error in README.
* Task ticket: [CU-86er3p8qz](https://app.clickup.com/t/86er3p8qz)


### _Effecting Scope_

* Fix display issue.


### _Description_

* Fix the badge error in GitHub repro home page and documentation home page.
