### PR TITLE
[CU-86er3krgj] Let incorrect usage of command line error to be clear and friendly

### DIFF
--- a/pymock_server/command/_parser.py
+++ b/pymock_server/command/_parser.py
@@ -31,6 +31,7 @@ class MockAPICommandParser:
         self._parser = None
 
         self._command_options: List["CommandOption"] = make_options()
+        self._subcommand_info: Optional[SysArg] = None
 
     @property
     def parser(self) -> argparse.ArgumentParser:
@@ -38,7 +39,12 @@ class MockAPICommandParser:
 
     @property
     def subcommand(self) -> Optional[SysArg]:
-        return SysArg.parse(sys.argv) if self.is_running_subcmd else None
+        if self.is_running_subcmd:
+            if self._subcommand_info is None:
+                self._subcommand_info = SysArg.parse(sys.argv)
+            return self._subcommand_info
+        else:
+            return None
 
     @property
     def is_running_subcmd(self) -> bool:

--- a/pymock_server/command/subcommand.py
+++ b/pymock_server/command/subcommand.py
@@ -1,6 +1,8 @@
 from enum import Enum
 from typing import List, Union
 
+from pymock_server.exceptions import NotFoundCommandLine
+
 
 class SubCommandLine(Enum):
     Base = "subcommand"
@@ -19,7 +21,7 @@ class SubCommandLine(Enum):
         for subcmd in SubCommandLine:
             if subcmd.value.lower() == v.lower():
                 return subcmd
-        raise ValueError(f"Cannot map anyone subcommand line with value '{v}'.")
+        raise NotFoundCommandLine(v)
 
     @staticmethod
     def major_cli() -> List["SubCommandLine"]:

--- a/pymock_server/exceptions.py
+++ b/pymock_server/exceptions.py
@@ -41,3 +41,11 @@ class NotSupportAPIDocumentVersion(ValueError):
 
     def __str__(self):
         return f"Currently, it doesn't support processing the configuration of API document version {self._version}."
+
+
+class NotFoundCommandLine(ValueError):
+    def __init__(self, subcmd: str):
+        self._subcmd = subcmd
+
+    def __str__(self):
+        return f"Cannot map anyone subcommand line with value '{self._subcmd}'."

--- a/pymock_server/exceptions.py
+++ b/pymock_server/exceptions.py
@@ -45,7 +45,7 @@ class NotSupportAPIDocumentVersion(ValueError):
 
 class NotFoundCommandLine(ValueError):
     def __init__(self, subcmd: str):
-        self._subcmd = subcmd
+        self.subcmd = subcmd
 
     def __str__(self):
-        return f"Cannot map anyone subcommand line with value '{self._subcmd}'."
+        return f"Cannot map anyone subcommand line with value '{self.subcmd}'."

--- a/test/unit_test/command/_base/process.py
+++ b/test/unit_test/command/_base/process.py
@@ -26,6 +26,12 @@ class BaseCommandProcessorTestSpec(metaclass=ABCMeta):
     def entry_point_under_test(self) -> Callable:
         return run_command_chain
 
+    def test_distribute_with_invalid_cmd(self, cmd_ps: BaseCommandProcessor):
+        with patch.object(sys, "argv", ["rest-server", "invalid"]):
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_ps.distribute()
+            assert exc_info.value.code == 1
+
     def test_with_command_processor(self, object_under_test: Callable, **kwargs):
         with patch.object(sys, "argv", self._given_command_line()):
             kwargs["cmd_ps"] = object_under_test

--- a/test/unit_test/command/parser.py
+++ b/test/unit_test/command/parser.py
@@ -1,8 +1,10 @@
+import re
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
 from pymock_server.command._parser import MockAPICommandParser
+from pymock_server.exceptions import NotFoundCommandLine
 
 
 class TestMockAPICommandParser:
@@ -18,3 +20,11 @@ class TestMockAPICommandParser:
 
         assert mock_api_parser is parser.parser
         mock_argparser_obj.assert_called_once()
+
+    def test_prop_subcommand(self, parser: MockAPICommandParser):
+        with patch("sys.argv", ["rest-server", "invalid"]):
+            with pytest.raises(NotFoundCommandLine) as exc_info:
+                parser.subcommand
+            re.search(
+                r"Cannot map.{0, 64}subcommand line.{0, 64}" + re.escape("invalid"), str(exc_info.value), re.IGNORECASE
+            )


### PR DESCRIPTION
### _Target_

* Let incorrect usage of command line error to be clear and friendly.
* Task ticket: [CU-86er3krgj](https://app.clickup.com/t/86er3krgj)
* Key change point:
    * as is:
        <img width="1083" alt="complex_error" src="https://github.com/user-attachments/assets/f60cefc1-1e96-415b-8235-2b78803b56a5" />
    * to be:
        <img width="842" alt="to_be_clear_error_msg" src="https://github.com/user-attachments/assets/e519ecdf-5ba3-44bd-ae9e-a7192af6cb8a" />


### _Effecting Scope_

* No any breaking change.


### _Description_

* Wrap the exception as customized error `NotFoundCommandLine`.
* Clear the error info if user input incorrect command line.
