### PR TITLE
[CU-86erajd7g] Import the warning mechanism if developers are viewing the non-latest stable version documentation.

### DIFF
--- a/docs/_overrides/main.html
+++ b/docs/_overrides/main.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block outdated %}
+  You're not viewing the latest stable version.
+  <a href="{{ '../' ~ base_url }}">
+    <strong>Click here to go to latest stable.</strong>
+  </a>
+{% endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,7 +13,7 @@ copyright: Copyright &copy; 2023 - 2025 Bryant Liu
 
 theme:
   name: material
-#  custom_dir: material/.overrides
+  custom_dir: ./docs/_overrides
   features:
     - announce.dismiss
     - content.action.edit


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    N/A.

[//]: # (The task ID in ClickUp [project: https://app.clickup.com/9018752317/v/f/90183126979/90182605225] which maps this change.)
* ### Task tickets:

    * Task ID: [CU-86erajd7g](https://app.clickup.com/t/86erajd7g).
    * Relative task IDs: N/A.

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    * In non-latest stable version page:
        <img width="1011" alt="non-latest_stable_version_doc" src="https://github.com/user-attachments/assets/f8a03728-6b60-47a2-a151-a48f6e7fb11d" />
    * In latest stable version page:
        <img width="1132" alt="latest_stable_version_doc" src="https://github.com/user-attachments/assets/a7060124-8243-42e7-b85e-80d40118b368" />


[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Improve the UX to let developers could be more easier to found that they're viewing non-latest stable version.


[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* Import the override mechanism in documentation and extend the UI about adding warning message at main page.
