### PR TITLE
[CU-86erde2f0] HotFix of CI error about broken SonarQube scan error

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -19,7 +19,7 @@ jobs:
 #    name: Build git tag and GitHub release if it needs
     needs: check_version-state
     if: ${{ needs.check_version-state.outputs.version_update_state == 'VERSION UPDATE' }}
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_build_git-tag_and_create_github-release.yaml@v7
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_build_git-tag_and_create_github-release.yaml@v7.1
     secrets:
       github_auth_token: ${{ secrets.GITHUB_TOKEN }}
     with:
@@ -31,7 +31,7 @@ jobs:
   push_python_pkg_to_pypi:
 #    name: Check about it could work finely by installing the Python package with setup.py file
     needs: build_git-tag_and_create_github-release
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_push_pypi.yaml@v7
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_push_pypi.yaml@v7.1
     with:
       build-type: poetry
       release-type: ${{ needs.build_git-tag_and_create_github-release.outputs.python_release_version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,7 +75,7 @@ jobs:
 #    name: Organize and generate the testing report and upload it to Codecov
     if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'master') }}
     needs: build-and-test
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_upload_test_cov_report.yaml@v7
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_upload_test_cov_report.yaml@v7.1
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
     with:
@@ -89,7 +89,7 @@ jobs:
 #    name: Organize and generate the testing report and upload it to Codecov
     if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'master') }}
     needs: build-and-test
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_upload_test_cov_report.yaml@v7
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_upload_test_cov_report.yaml@v7.1
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
     with:
@@ -103,7 +103,7 @@ jobs:
 #    name: Organize and generate the testing report and upload it to Codecov
     if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'master') }}
     needs: build-and-test
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_upload_test_cov_report.yaml@v7
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_upload_test_cov_report.yaml@v7.1
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
     with:
@@ -117,7 +117,7 @@ jobs:
 #    name: Organize and generate the testing report and upload it to Codecov
     if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'master') }}
     needs: build-and-test
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_upload_test_cov_report.yaml@v7
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_upload_test_cov_report.yaml@v7.1
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
     with:
@@ -131,7 +131,7 @@ jobs:
 #    name: SonarCloud Scan
     if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'master') }}
     needs: build-and-test
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_sonarqube_scan.yaml@v7
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_sonarqube_scan.yaml@v7.1
     secrets:
       sonar_token: ${{ secrets.SONAR_TOKEN }}
     with:
@@ -142,7 +142,7 @@ jobs:
 #    name: Check about it could work finely by installing the Python package with setup.py file
     needs: [unit-test_codecov_finish, integration-test_codecov_finish, system-test_codecov_finish, all-test_codecov_finish, sonarcloud_finish]
     if: ${{ github.ref_name == 'release' || github.ref_name == 'master' }}
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_pre-building_test.yaml@v7
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_pre-building_test.yaml@v7.1
     with:
       build-type: poetry
       python_package_name: pymock-server

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -45,7 +45,7 @@ jobs:
 #    name: Check the package version info to make sure whether it should release Docker image or not.
     needs: check_version-state
     if: ${{ needs.check_version-state.outputs.version_update_state == 'VERSION UPDATE' }}
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_build_git-tag_and_create_github-release.yaml@v7
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_build_git-tag_and_create_github-release.yaml@v7.1
     secrets:
       github_auth_token: ${{ secrets.GITHUB_TOKEN }}
     with:

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -72,7 +72,7 @@ jobs:
 #    name: Check the package version info to make sure whether it should release Docker image or not.
     needs: check_version-state
     if: ${{ needs.check_version-state.outputs.version_update_state == 'VERSION UPDATE' }}
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_build_git-tag_and_create_github-release.yaml@v7
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_build_git-tag_and_create_github-release.yaml@v7.1
     secrets:
       github_auth_token: ${{ secrets.GITHUB_TOKEN }}
     with:

--- a/.github/workflows/rw_build_and_test.yaml
+++ b/.github/workflows/rw_build_and_test.yaml
@@ -6,21 +6,21 @@ on:
 jobs:
   prep_unit-test:
 #    name: Prepare all unit test items
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_get_tests.yaml@v7
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_get_tests.yaml@v7.1
     with:
       shell_arg: test/unit_test/
 
 
   prep_integration-test:
 #    name: Prepare all integration test items
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_get_tests.yaml@v7
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_get_tests.yaml@v7.1
     with:
       shell_arg: test/integration_test/
 
 
   prep_system-test:
 #    name: Prepare all system test items
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_get_tests.yaml@v7
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_get_tests.yaml@v7.1
     with:
       shell_arg: test/system_test/
 
@@ -56,7 +56,7 @@ jobs:
 #    name: For unit test, organize and generate the testing report and upload it to Codecov
     if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'master') }}
     needs: run_unit-test
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@v7
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@v7.1
     with:
       test_type: unit-test
 
@@ -65,7 +65,7 @@ jobs:
 #    name: For unit test, organize and generate the testing report and upload it to Codecov
     if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'master') }}
     needs: run_integration-test
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@v7
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@v7.1
     with:
       test_type: integration-test
 
@@ -74,7 +74,7 @@ jobs:
 #    name: For unit test, organize and generate the testing report and upload it to Codecov
     if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'master') }}
     needs: run_system-test
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@v7
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@v7.1
     with:
       test_type: system-test
 
@@ -83,6 +83,6 @@ jobs:
 #    name: Organize and generate the testing report and upload it to Codecov
     if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'master') }}
     needs: [run_unit-test, run_integration-test, run_system-test]
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@v7
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@v7.1
     with:
       test_type: all-test

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,4 @@
+sonar.host.url=https://sonarcloud.io
 sonar.projectKey=Chisanan232_PyMock-Server
 sonar.organization=chisanan232
 


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    HotFix of CI error about broken SonarQube scan error.

[//]: # (The task ID in ClickUp [project: https://app.clickup.com/9018752317/v/f/90183126979/90182605225] which maps this change.)
* ### Task tickets:

    * Task ID: [CU-86erde2f0](https://app.clickup.com/t/86erde2f0).
    * Relative task IDs: N/A.
    * Relative PR: https://github.com/Chisanan232/GitHub-Action_Reusable_Workflows-Python/pull/76

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    Broken CI.
        * Ref: https://github.com/Chisanan232/PyMock-Server/actions/runs/13034201856
        * Key screenshot: <img width="1423" alt="Screenshot 2025-01-30 at 8 28 33 PM" src="https://github.com/user-attachments/assets/77bcad62-d169-4918-94e7-82fcb83c1aad" />


[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Fix broken CI because of deprecated action `SonarSource/sonarcloud-github-action`.


[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* Upgrade the CI workflow to fix the broken job about triggering SonarQube scan.
* Add setting about SonarQube host URL.
